### PR TITLE
Add exFAT filesystem support

### DIFF
--- a/desktop/packages.txt
+++ b/desktop/packages.txt
@@ -7,6 +7,7 @@ wget curl libssl-dev
 htop cron
 gnome-tweaks ibus ibus-hangul fonts-hack-ttf fonts-powerline
 flex bison
+exfat-fuse exfat-utils
 
 libcairo2-dev libexpat1-dev libgtk-3-dev libgtksourceview2.0-dev libgtksourceview-3.0-dev
 libreadline-dev


### PR DESCRIPTION
[Reference Link](https://linuxize.com/post/how-to-mount-an-exfat-drive-on-ubuntu/)