### PR TITLE
Add packages for Xilinx toolchain

### DIFF
--- a/sandbox-20.04/packages.txt
+++ b/sandbox-20.04/packages.txt
@@ -16,6 +16,7 @@ gcc-riscv64-linux-gnu gcc-aarch64-linux-gnu
 gdb-multiarch
 qemu-user-static qemu-system-arm qemu-system-misc=1:4.2-3ubuntu6
 virt-manager
+libncurses5 libtinfo5
 
 fonts-hack-ttf fonts-powerline fonts-dejavu ttf-dejavu fonts-symbola
 texlive-full


### PR DESCRIPTION
* Add libncurses5 & libtinfo5

(Ubuntu 20.04에서도) 이게 없으면 Xilinx toolchain 설치가 끝나지 않습니다.

Ref 1: https://forums.xilinx.com/t5/Installation-and-Licensing/Vivado-2018-3-Final-Processing-hangs-at-Generating-installed/m-p/972114#M25861
Ref 2: https://blog.lazy-evaluation.net/posts/linux/vivado-2018-3-buster.html